### PR TITLE
fix of bug with removed keys in processDeque

### DIFF
--- a/internal/store.go
+++ b/internal/store.go
@@ -12,9 +12,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Yiling-J/theine-go/internal/bf"
 	"github.com/gammazero/deque"
 	"github.com/zeebo/xxh3"
+
+	"github.com/Yiling-J/theine-go/internal/bf"
 )
 
 const (
@@ -369,7 +370,6 @@ func (s *Store[K, V]) processDeque(shard *Shard[K, V]) {
 	removedkv := make([]dequeKV[K, V], 0, 2)
 	// expired
 	expiredkv := make([]dequeKV[K, V], 0, 2)
-	// expired
 	for shard.qlen > int(shard.qsize) {
 		evicted := shard.deque.PopBack()
 		evicted.deque = false
@@ -394,9 +394,7 @@ func (s *Store[K, V]) processDeque(shard *Shard[K, V]) {
 					deleted := shard.delete(evicted)
 					// double check because entry maybe removed already by Delete API
 					if deleted {
-						removedkv = append(
-							expiredkv, s.kvBuilder(evicted),
-						)
+						removedkv = append(removedkv, s.kvBuilder(evicted))
 						s.postDelete(evicted)
 					}
 				}


### PR DESCRIPTION
`processDeque` function has suspicious logic:
``` golang
if deleted {
	removedkv = append(
		expiredkv, s.kvBuilder(evicted),
	)
	s.postDelete(evicted)
}
```

It looks like a typo as `removedkv` slice always reseted with `expiredkv` content in case of new evicted element.

Unfortunately, I didn't managed to implement test that checks this behaviour. I am ready to do that - but need some guidance from maintainers.

This PR change the logic to the following one: `removedkv = append(removedkv, s.kvBuilder(evicted))`