### PR TITLE
doc: add reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Theine
+[![Go Reference](https://pkg.go.dev/badge/github.com/Yiling-J/theine-go.svg)](https://pkg.go.dev/github.com/Yiling-J/theine-go)
 [![codecov](https://codecov.io/gh/Yiling-J/theine-go/branch/main/graph/badge.svg?token=E1HJLJH07V)](https://codecov.io/gh/Yiling-J/theine-go)
 
 High performance in-memory & hybrid cache inspired by [Caffeine](https://github.com/ben-manes/caffeine).


### PR DESCRIPTION
In README, missing reference link.