### PR TITLE
Use x/sys/cpu cacheline size

### DIFF
--- a/internal/store.go
+++ b/internal/store.go
@@ -472,13 +472,9 @@ func (s *Store[K, V]) Len() int {
 	return total
 }
 
-// spread hash before get index
 func (s *Store[K, V]) index(key K) (uint64, int) {
 	base := s.hasher.hash(key)
-	h := ((base >> 16) ^ base) * 0x45d9f3b
-	h = ((h >> 16) ^ h) * 0x45d9f3b
-	h = (h >> 16) ^ h
-	return base, int(h & uint64(s.shardCount-1))
+	return base, int(base & uint64(s.shardCount-1))
 }
 
 func (s *Store[K, V]) postDelete(entry *Entry[K, V]) {

--- a/internal/xruntime/xruntime.go
+++ b/internal/xruntime/xruntime.go
@@ -17,11 +17,14 @@ package xruntime
 
 import (
 	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/cpu"
 )
 
 const (
 	// CacheLineSize is useful for preventing false sharing.
-	CacheLineSize = 64
+	CacheLineSize = unsafe.Sizeof(cpu.CacheLinePad{})
 )
 
 // Parallelism returns the maximum possible number of concurrently running goroutines.


### PR DESCRIPTION
also remove supplemental hash beacuse go doesn't allow hash override and xxh3 is good enough. And the supplemental hash function currenly used is for 32bit, which is wrong. should use 64bit(https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key)