### PR TITLE
accurate hit/miss counter

### DIFF
--- a/internal/store.go
+++ b/internal/store.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	MAX_READ_BUFF_SIZE  = 64
 	MIN_WRITE_BUFF_SIZE = 4
 	MAX_WRITE_BUFF_SIZE = 1024
 )
@@ -229,6 +228,8 @@ func (s *Store[K, V]) getFromShard(key K, hash uint64, shard *Shard[K, V]) (V, b
 			s.policy.hit.Add(1)
 			value = entry.value
 		}
+	} else {
+		s.policy.miss.Add(1)
 	}
 	shard.mu.RUnlock(tk)
 
@@ -542,7 +543,6 @@ func (s *Store[K, V]) removeEntry(entry *Entry[K, V], reason RemoveReason) {
 }
 
 func (s *Store[K, V]) drainRead(buffer []ReadBufItem[K, V]) {
-	s.policy.total.Add(MAX_READ_BUFF_SIZE)
 	s.mlock.Lock()
 	for _, e := range buffer {
 		s.policy.Access(e)

--- a/internal/store.go
+++ b/internal/store.go
@@ -224,6 +224,7 @@ func (s *Store[K, V]) getFromShard(key K, hash uint64, shard *Shard[K, V]) (V, b
 		expire := entry.expire.Load()
 		if expire != 0 && expire <= s.timerwheel.clock.NowNano() {
 			ok = false
+			s.policy.miss.Add(1)
 		} else {
 			s.policy.hit.Add(1)
 			value = entry.value

--- a/internal/store_test.go
+++ b/internal/store_test.go
@@ -114,3 +114,21 @@ func TestDoorKeeperDynamicSize(t *testing.T) {
 	}
 	require.True(t, shard.dookeeper.Capacity > 100000)
 }
+
+func TestPolicyCounter(t *testing.T) {
+	store := NewStore[int, int](1000, false, nil, nil, nil, 0, 0, nil)
+	for i := 0; i < 1000; i++ {
+		store.Set(i, i, 1, 0)
+	}
+	// hit
+	for i := 0; i < 1600; i++ {
+		store.Get(100)
+	}
+	// miss
+	for i := 0; i < 1600; i++ {
+		store.Get(10000)
+	}
+
+	require.Equal(t, int64(1600), store.policy.hit.Value())
+	require.Equal(t, int64(1600), store.policy.miss.Value())
+}


### PR DESCRIPTION
Current counter is inaccurate because it only counts items in the read buffer, and add wrong size. But the overall hit ratio trend is still correct. The hit ratio is used in policy to make it adaptive.

To reuse the counters in the stats API, they should be accurate. This PR updates the counter directly in the API rather than in the buffer. Additionally, it changes the `total` to `miss` to reduce contention.

Throughput and hit ratio performance should remain unchanged (tested).