### PR TITLE
reduce set allocation

### DIFF
--- a/internal/store_test.go
+++ b/internal/store_test.go
@@ -108,7 +108,6 @@ func TestStore_RemoveDeque(t *testing.T) {
 	shard := store.shards[index]
 	store.Set(123, 123, 8, 0)
 	entry := shard.hashmap[123]
-	store.Delete(123)
 	// this will send key 123 to policy because deque is full
 	q.size = 10
 	q.len = 10
@@ -116,6 +115,8 @@ func TestStore_RemoveDeque(t *testing.T) {
 	entryNew.cost = 1
 	store.queue.Push(h, entryNew, 1, false)
 	shard.hashmap[1] = entryNew
+	// delete key
+	store.Delete(123)
 
 	time.Sleep(1 * time.Second)
 	store.writeChan <- WriteBufItem[int, int]{}


### PR DESCRIPTION
100% Set&Create benchmark, `uint64` key and `[512]byte` value:

**before:**
```
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkCache/otter_reads=0%,writes=100%-6         	 1000000	      1036 ns/op	    965062 ops/s	     582 B/op	       1 allocs/op

BenchmarkCache/theine_reads=0%,writes=100%-6        	 2075300	       562.5 ns/op	   1777821 ops/s	      76 B/op	       2 allocs/op

BenchmarkCache/ristretto_reads=0%,writes=100%-6     	 6303217	       166.0 ns/op	   6024788 ops/s	     612 B/op	       3 allocs/op
```


**after:**
```
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkCache/otter_reads=0%,writes=100%-6         	 1000000	      1196 ns/op	    836077 ops/s	     582 B/op	       1 allocs/op

BenchmarkCache/theine_reads=0%,writes=100%-6        	 2076139	       559.9 ns/op	   1786018 ops/s	      12 B/op	       0 allocs/op

BenchmarkCache/ristretto_reads=0%,writes=100%-6     	 7765894	       170.9 ns/op	   5851165 ops/s	     612 B/op	       3 allocs/op
```


The reason Ristretto is fast (170.9 ns/op) is that it [proactively drops Set](https://github.com/dgraph-io/ristretto/blob/ce5561f7d9a89363e9d889095428fa9ef84f9c76/cache.go#L303):
```go
select {
	case c.setBuf <- i:
		return true
	default:
		...
```