### PR TITLE
Fix proactive expiration delay in timing wheel

### DIFF
--- a/internal/timerwheel.go
+++ b/internal/timerwheel.go
@@ -113,10 +113,7 @@ func (tw *TimerWheel[K, V]) advance(now int64, remove func(entry *Entry[K, V], r
 
 func (tw *TimerWheel[K, V]) expire(index int, prevTicks int64, delta int64, remove func(entry *Entry[K, V], reason RemoveReason)) {
 	mask := tw.buckets[index] - 1
-	steps := tw.buckets[index]
-	if delta < int64(steps) {
-		steps = uint(delta)
-	}
+	steps := min(uint(1+int(delta)), tw.buckets[index])
 	start := prevTicks & int64(mask)
 	end := start + int64(steps)
 	for i := start; i < end; i++ {

--- a/internal/timerwheel_test.go
+++ b/internal/timerwheel_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -77,6 +78,30 @@ func TestSchedule(t *testing.T) {
 	require.True(t, found)
 }
 
+func TestAdvanceCompact(t *testing.T) {
+	tw := NewTimerWheel[string, string](5000000)
+	entries := make([]*Entry[string, string], 5000000)
+	for i := 0; i < 5000000; i++ {
+		entries[i] = NewEntry(fmt.Sprintf("k%d", i+1), "", 1, expire(tw.clock.NowNano(), int64(i+1)))
+		tw.schedule(entries[i])
+	}
+	now := tw.clock.NowNano()
+
+	evicted := []string{}
+	prev := 0
+	counter := 0
+	for second := 1; second <= 5000005; second++ {
+		tw.advance(now+(time.Second*time.Duration(second)).Nanoseconds(), func(entry *Entry[string, string], reason RemoveReason) {
+			counter += 1
+			evicted = append(evicted, entry.key)
+		})
+		require.True(t, counter-prev >= 0 && counter-prev <= 5, counter-prev)
+		prev = counter
+	}
+
+	require.Len(t, evicted, 5000000)
+}
+
 func TestAdvance(t *testing.T) {
 	tw := NewTimerWheel[string, string](1000)
 	entries := []*Entry[string, string]{
@@ -98,7 +123,7 @@ func TestAdvance(t *testing.T) {
 	})
 	require.ElementsMatch(t, []string{"k1", "k2", "k3"}, evicted)
 
-	tw.advance(tw.clock.NowNano()+(time.Second*time.Duration(200)).Nanoseconds(), func(entry *Entry[string, string], reason RemoveReason) {
+	tw.advance(tw.clock.NowNano()+(time.Second*time.Duration(121)).Nanoseconds(), func(entry *Entry[string, string], reason RemoveReason) {
 		evicted = append(evicted, entry.key)
 	})
 

--- a/internal/timerwheel_test.go
+++ b/internal/timerwheel_test.go
@@ -80,12 +80,12 @@ func TestSchedule(t *testing.T) {
 
 func TestAdvanceCompact(t *testing.T) {
 	tw := NewTimerWheel[string, string](5000000)
+	now := tw.clock.NowNano()
 	entries := make([]*Entry[string, string], 5000000)
 	for i := 0; i < 5000000; i++ {
-		entries[i] = NewEntry(fmt.Sprintf("k%d", i+1), "", 1, expire(tw.clock.NowNano(), int64(i+1)))
+		entries[i] = NewEntry(fmt.Sprintf("k%d", i+1), "", 1, expire(now, int64(i+1)))
 		tw.schedule(entries[i])
 	}
-	now := tw.clock.NowNano()
 
 	evicted := []string{}
 	prev := 0
@@ -95,7 +95,7 @@ func TestAdvanceCompact(t *testing.T) {
 			counter += 1
 			evicted = append(evicted, entry.key)
 		})
-		require.True(t, counter-prev >= 0 && counter-prev <= 5, counter-prev)
+		require.True(t, counter-prev >= 0 && counter-prev <= 2, counter-prev)
 		prev = counter
 	}
 


### PR DESCRIPTION
The previous timing wheel logic only expired entries at the previous index when the wheel advanced. For example, when the minutes wheel moved from index 0 to 1, only index 0 was checked for expiration, not index 1. This caused a one-unit delay in proactive expiration.

To address this, the logic is updated to check the range [current, current + steps] during each advancement. This ensures that proactive expiration occurs without delay.

Fix https://github.com/Yiling-J/theine-go/issues/64