### PR TITLE
fix hanging on simultaneous Wait() calls

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -435,3 +435,34 @@ func TestCache_Zipf(t *testing.T) {
 	require.True(t, 1-float64(miss.Load())/float64(total) > 0.5)
 	require.True(t, 1-float64(miss.Load())/float64(total) < 0.6)
 }
+
+func TestCache_Wait(t *testing.T) {
+	const n = 1000
+
+	client, err := theine.NewBuilder[int, int](2 * n).Build()
+	require.Nil(t, err)
+	defer client.Close()
+
+	wg := sync.WaitGroup{}
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		ii := i
+		go func() {
+			client.Set(ii, ii, 1)
+			client.Wait()
+			wg.Done()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "test timed out after 10s")
+	case <-done:
+	}
+}

--- a/internal/store.go
+++ b/internal/store.go
@@ -708,17 +708,17 @@ func (s *Store[K, V]) sinkWrite(item WriteBufItem[K, V]) {
 }
 
 func (s *Store[K, V]) drainWrite() {
-	var wait bool
+	var wait int
 	for _, item := range s.writeBuffer {
 		if item.code == WAIT {
-			wait = true
+			wait += 1
 			continue
 		}
 		s.sinkWrite(item)
 	}
 
 	s.writeBuffer = s.writeBuffer[:0]
-	if wait {
+	for i := 0; i < wait; i++ {
 		s.waitChan <- true
 	}
 }


### PR DESCRIPTION
The test in this MR fails on the `main` branch
If several goroutines happen to have `WAIT` signal in the same `writeBuffer`, only one of them gets the value from `s.waitChan` and others are stuck (at least until they steal that signal from later writes)